### PR TITLE
add ezmlm list detection, reject null senders to lists

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 # Revision history for Perl extension Qmail::Deliverable.
 # The format for this changelog is described at http://use.perl.org/~hex/journal/34882
 
+VERSION:      1.08
+fix:          fix interpretation of wildcard assignments [rt.cpan.org #131280]
+info:         This version was provided by Martin Sluka.
+
 VERSION:      1.07
 fix:          default@example.org in vpopmail/valias now works as intended.
 new:          Support for vpopmail user-ext (disabled by default).

--- a/lib/Qmail/Deliverable.pm
+++ b/lib/Qmail/Deliverable.pm
@@ -289,6 +289,7 @@ sub deliverable {
         return 0x00;
     }
 
+    return 0x14 if grep /ezmlm/, @dot_qmail;
     return 0x12 if grep /^\|/, @dot_qmail;
 
     return 0xf1;
@@ -401,6 +402,7 @@ Possible return values are:
     0x11   Deliverability unknown: permission denied for any file
     0x12   Deliverability unknown: qmail-command called in dot-qmail file
     0x13   Deliverability unknown: bouncesaying with program
+    0x14   Deliverable, probable:  ezmlm mailing list
 
     0x21   Temporarily undeliverable: group/world writable
     0x22   Temporarily undeliverable: homedir is sticky

--- a/lib/Qmail/Deliverable.pm
+++ b/lib/Qmail/Deliverable.pm
@@ -5,7 +5,7 @@ use 5.006;
 use Carp qw(carp);
 use base 'Exporter';
 
-our $VERSION = '1.07';
+our $VERSION = '1.08';
 our @EXPORT_OK = qw/reread_config qmail_local dot_qmail deliverable qmail_user/;
 our %EXPORT_TAGS = (all => \@EXPORT_OK);
 our $VPOPMAIL_EXT = 0;
@@ -151,7 +151,7 @@ sub qmail_user {
             my $try = substr $local, 0, $_;
             if (exists $users_wild{$try}) {
                 my @assign = split /:/, $users_wild{$try}, 7;
-                $assign[5] = substr($local, $_) . $assign[5];
+                $assign[5] .= substr($local, $_);
                 return @assign;
             }
         }

--- a/qpsmtpd-plugin/qmail_deliverable
+++ b/qpsmtpd-plugin/qmail_deliverable
@@ -180,6 +180,12 @@ sub rcpt_handler {
     $self->log(LOGINFO, "error, permission failure"),       $k++ if $rv == 0x11;
     $self->log(LOGINFO, "pass, qmail-command in dot-qmail"),$k++ if $rv == 0x12;
     $self->log(LOGINFO, "pass, bouncesaying with program"), $k++ if $rv == 0x13;
+    if ( $rv == 0x14 ) {
+        my $s = $transaction->sender->address;
+        return (DENY, "fail, mailing lists do not accept null senders")
+            if ( ! $s || $s eq '<>');
+        $self->log(LOGINFO, "pass, ezmlm list"); $k++;
+    };
     $self->log(LOGINFO, "Temporarily undeliverable: group/world writable"), $k++
                                                                  if $rv == 0x21;
     $self->log(LOGINFO, "Temporarily undeliverable: sticky home directory"),$k++


### PR DESCRIPTION
- detect ezmlm lists, and reject emails to lists with null senders (bounces, autoreplies, DSNs, etc) should never send email to a list. But spammers do often spam with forged list addresses, and this prevents our mail server from accepting a forged bounce which can't be delivered.